### PR TITLE
Fix Pill bottles Not able to be labeled

### DIFF
--- a/code/game/objects/items/weapons/storage/firstaid.dm
+++ b/code/game/objects/items/weapons/storage/firstaid.dm
@@ -156,6 +156,9 @@
 			return
 	return
 
+/obj/item/weapon/storage/pill_bottle/attackby(obj/item/I, mob/user, params)
+	..()
+
 /obj/item/weapon/storage/box/silver_sulf
 	name = "box of silver sulfadiazine patches"
 	desc = "Contains patches used to treat burns."


### PR DESCRIPTION
Pill bottles could not be labeled was able to fix it by adding the
attackby function to the pill bottles  object code
